### PR TITLE
OJ-1799: Convert clickopsed state machine get question

### DIFF
--- a/infrastructure/samconfig.toml
+++ b/infrastructure/samconfig.toml
@@ -1,6 +1,6 @@
 version = 0.1
 [default.deploy.parameters]
-stack_name = "kbv-hmrc"
+stack_name = "connor-kbv-hmrc"
 resolve_s3 = true
 s3_prefix = "kbv-hmrc"
 region = "eu-west-2"

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -120,6 +120,10 @@ Resources:
       DefinitionUri: ../step-functions/get-question.asl.json
       Role: !GetAtt StateMachineRole.Arn
       Name: !Sub "${AWS::StackName}-GetQuestion"
+      DefinitionSubstitutions:
+        StackName: !Sub "${AWS::StackName}"
+        QuestionsTableName: !Ref "QuestionsTable"
+        GetQuestionsStateMachineArn: !GetAtt GetQuestionsStateMachine.Arn
 
   PostAnswerStateMachine:
     Type: AWS::Serverless::StateMachine

--- a/step-functions/get-question.asl.json
+++ b/step-functions/get-question.asl.json
@@ -1,8 +1,8 @@
 {
-  "Comment": "A description of my state machine",
-  "StartAt": "Check sessionId present",
+  "Comment": "Return any unanswered question if available.",
+  "StartAt": "Check Session ID field present",
   "States": {
-    "Check sessionId present": {
+    "Check Session ID field present": {
       "Type": "Choice",
       "Choices": [
         {
@@ -13,9 +13,9 @@
           "Next": "Error: Missing sessionId"
         }
       ],
-      "Default": "Check nino present"
+      "Default": "Check NINO field present"
     },
-    "Check nino present": {
+    "Check NINO field present": {
       "Type": "Choice",
       "Choices": [
         {
@@ -26,17 +26,17 @@
           "Next": "Error: Missing nino"
         }
       ],
-      "Default": "Execute DemoPopulateQuestionsTable"
+      "Default": "GET Questions from HMRC"
     },
     "Error: Missing nino": {
       "Type": "Pass",
       "End": true
     },
-    "Execute DemoPopulateQuestionsTable": {
+    "GET Questions from HMRC": {
       "Type": "Task",
       "Resource": "arn:aws:states:::states:startExecution.sync:2",
       "Parameters": {
-        "StateMachineArn": "arn:aws:states:eu-west-2:404250751813:stateMachine:kbv-hmrc-GetQuestions",
+        "StateMachineArn": "${GetQuestionsStateMachineArn}",
         "Input": {
           "sessionId.$": "$.sessionId",
           "nino.$": "$.nino"
@@ -49,7 +49,7 @@
       "Type": "Task",
       "Next": "Check if we have any unanswered questions",
       "Parameters": {
-        "TableName": "demo-hmrc-questions-composite",
+        "TableName": "${QuestionsTableName}",
         "KeyConditionExpression": "sessionId = :value",
         "FilterExpression": "answered = :answeredValue",
         "ExpressionAttributeValues": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- `get-question` state machine can now be deployed dynamically

### Why did it change

- No more hard coded values

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1799](https://govukverify.atlassian.net/browse/OJ-1799)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
