### PR TITLE
OJ-1840 allow pipelines to deploy hmrc kbv stack

### DIFF
--- a/.github/workflows/post-merge-deploy-to-build.yml
+++ b/.github/workflows/post-merge-deploy-to-build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup SAM
         uses: aws-actions/setup-sam@v2
         with:
-          version: 1.74.0
+          version: 1.89.0
 
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup SAM
         uses: aws-actions/setup-sam@v2
         with:
-          version: 1.74.0
+          version: 1.89.0
 
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v2

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -411,6 +411,10 @@ Resources:
               - logs:*
             Resource:
               - "*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
 
   GetIvqQuestionsStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
@@ -445,6 +449,10 @@ Resources:
               - logs:*
             Resource:
               - "*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
       DefinitionSubstitutions:
         PersonalIdentityTableName: !Ref PersonalIdentityTable
         ExecuteStateMachineFunctionName: !Ref ExecuteStateMachineFunction
@@ -498,6 +506,10 @@ Resources:
               - logs:*
             Resource:
               - "*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
       DefinitionSubstitutions:
         AnswersIvqStateMachine: !Ref "PostIvqAnswersStateMachine"
         QuestionsTableName: !Ref "QuestionsTable"
@@ -532,6 +544,10 @@ Resources:
               - logs:*
             Resource:
               - "*"
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
       Name: !Sub "${AWS::StackName}-PostIvqAnswers"
       DefinitionSubstitutions:
         BearerTokenName: !Ref BearerTokenName

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -45,6 +45,10 @@ Globals:
     Architectures:
       - arm64
     Timeout: 3
+    PermissionsBoundary: !If
+      - UsePermissionsBoundary
+      - !Ref PermissionsBoundary
+      - !Ref AWS::NoValue
 
 Resources:
   PublicKbvHmrcApi:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -4,7 +4,10 @@ Description: "Digital Identity IPV CRI KBV HMRC API"
 
 Parameters:
   BearerTokenName:
+    Description: "The name of the bearer token parameter"
     Type: String
+    # Temporary - solution to be changed once cross account behaviour implemented
+    Default: "HMRCBearerToken"
   PermissionsBoundary:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -286,10 +286,6 @@ Resources:
     Properties:
       CodeUri: ../lambdas/submit-answer
       Handler: submit-answer-handler.lambdaHandler
-      FunctionUrlConfig:
-        AuthType: AWS_IAM
-        Cors:
-          AllowOrigins: ["*"]
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -304,10 +300,6 @@ Resources:
     Properties:
       CodeUri: ../lambdas/fetch-questions
       Handler: fetch-questions-handler.lambdaHandler
-      FunctionUrlConfig:
-        AuthType: AWS_IAM
-        Cors:
-          AllowOrigins: ["*"]
     Metadata:
       BuildMethod: esbuild
       BuildProperties:
@@ -564,9 +556,6 @@ Outputs:
     Description: "Implicit IAM Role created for ExecuteStateMachine function"
     Value: !GetAtt ExecuteStateMachineFunctionRole.Arn
 
-  SubmitAnswerFunctionURLEndpoint:
-    Description: FURLFunction function name
-    Value: !GetAtt SubmitAnswerFunctionUrl.FunctionUrl
   SubmitAnswerFunction:
     Description: "SubmitAnswer Lambda Function ARN"
     Value: !GetAtt SubmitAnswerFunction.Arn
@@ -574,9 +563,6 @@ Outputs:
     Description: "Implicit IAM Role created for SubmitAnswer function"
     Value: !GetAtt SubmitAnswerFunctionRole.Arn
 
-  FetchQuestionsFunctionURLEndpoint:
-    Description: FURLFunction function name
-    Value: !GetAtt FetchQuestionsFunctionUrl.FunctionUrl
   FetchQuestionsFunction:
     Description: "FetchQuestions Lambda Function ARN"
     Value: !GetAtt FetchQuestionsFunction.Arn

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -3,6 +3,14 @@ Transform: AWS::Serverless-2016-10-31
 Description: "Digital Identity IPV CRI KBV HMRC API"
 
 Parameters:
+  CodeSigningEnabled:
+    Type: "String"
+    Default: "true"
+  CodeSigningConfigArn:
+    Type: String
+    Default: "none"
+    Description: >
+      The ARN of the Code Signing Config to use, provided by the deployment pipeline
   BearerTokenName:
     Description: "The name of the bearer token parameter"
     Type: String
@@ -28,6 +36,9 @@ Parameters:
     Default: "common-cri-api"
 
 Conditions:
+  EnforceCodeSigning: !Equals
+    - !Ref CodeSigningEnabled
+    - true
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
@@ -48,6 +59,10 @@ Globals:
     PermissionsBoundary: !If
       - UsePermissionsBoundary
       - !Ref PermissionsBoundary
+      - !Ref AWS::NoValue
+    CodeSigningConfigArn: !If
+      - EnforceCodeSigning
+      - !Ref CodeSigningConfigArn
       - !Ref AWS::NoValue
 
 Resources:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Tried and tested changes necessary for the stack to be deployable via the pipelines

### Why did it change

- Sam version change was necessary as 1.74.0 didn't accept `???` as a wildcard for permissions
- Code signing, permissions boundaries and function url changes were all necessary to allow the stack to deploy

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1840](https://govukverify.atlassian.net/browse/OJ-1840)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed

### Other considerations

- [x] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1840]: https://govukverify.atlassian.net/browse/OJ-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ