### PR TITLE
OJ-1841: Added Issue Credential Endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -108,24 +108,15 @@
     }
   ],
   "results": {
-    "step-functions/get-questions.asl.json": [
+    "infrastructure/public-api.yaml": [
       {
-        "type": "Secret Keyword",
-        "filename": "step-functions/get-questions.asl.json",
-        "hashed_secret": "a795cf6b02adf74a284dba736b0a773758965dab",
+        "type": "JSON Web Token",
+        "filename": "infrastructure/public-api.yaml",
+        "hashed_secret": "d6b66ddd9ea7dbe760114bfe9a97352a5e139134",
         "is_verified": false,
-        "line_number": 68
-      }
-    ],
-    "step-functions/post-answers.asl.json": [
-      {
-        "type": "Secret Keyword",
-        "filename": "step-functions/post-answers.asl.json",
-        "hashed_secret": "a795cf6b02adf74a284dba736b0a773758965dab",
-        "is_verified": false,
-        "line_number": 58
+        "line_number": 129
       }
     ]
   },
-  "generated_at": "2023-08-11T09:39:56Z"
+  "generated_at": "2023-09-18T11:08:43Z"
 }

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -103,6 +103,70 @@ paths:
         passthroughBehavior: "when_no_match"
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws_proxy"
+  /credential/issue:
+    summary: Resource for the HMRC KBV API
+    description: >-
+      This API is expected to be called by the IPV core backend directly as the
+      final part of the OpenId/Oauth Flow
+    parameters:
+      - name: Authorization
+        in: header
+        required: true
+        description: "A valid access_token (e.g.: authorization: Bearer access-token-value)."
+        schema:
+          type: string
+    post:
+      summary: POST request using a valid access token
+      responses:
+        "200":
+          description: 200 Ok
+          content:
+            application/jwt:
+              schema:
+                type: string
+                format: application/jwt
+                pattern: ^([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]+)$
+                example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        "400":
+          description: 400 Bad Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          description: 500 Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+      security:
+        - api_key:
+            Fn::If:
+              - IsNotDevEnvironment
+              - []
+              - Ref: AWS::NoValue
+      x-amazon-apigateway-request-validator: "Validate both"
+      x-amazon-apigateway-integration:
+        httpMethod: "POST"
+        passthroughBehavior: "when_no_templates"
+        type: "aws"
+        credentials:
+          Fn::Sub: ${ExecuteStateMachineRole.Arn}
+        uri:
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:states:action/StartSyncExecution
+        requestTemplates:
+          application/json:
+            Fn::Sub: |-
+              {
+                "input": "{\"bearerToken\": \"$input.params('Authorization').trim()\"}",
+                "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-IssueCredential"
+              }
+        responses:
+          "200":
+            statusCode: 200
+            responseTemplates:
+              application/json:
+                Fn::Sub: $input.path('$').output
 
 components:
   schemas:


### PR DESCRIPTION
## Proposed changes

Add Issue Credential endpoint to the public-api.yaml

### What changed

This endpoint calls a Step function that handles creating, generating claimset and signing it.

### Why did it change

Needed as part the OAuth flow of the Credential Cri 

- [OJ-1841](https://govukverify.atlassian.net/browse/OJ-1841)



[OJ-1841]: https://govukverify.atlassian.net/browse/OJ-1841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ