### PR TITLE
OJ-1904: Added authorizationCode generation to the post answers state machine

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -504,6 +504,20 @@ Resources:
       LogGroupName: !Sub /aws/vendedlogs/states/aws/apigateway/${AWS::StackName}-PostIvqAnswers-state-machine-logs
       RetentionInDays: 365
 
+  CreateAuthCodeFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ../lambdas/submit-answer
+      Handler: create-auth-code-handler.lambdaHandler
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Minify: true
+        Target: "es2020"
+        Sourcemap: true
+        EntryPoints:
+          - src/create-auth-code-handler.ts
+
   PostAnswerStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
@@ -517,8 +531,14 @@ Resources:
         IncludeExecutionData: True
         Level: ALL
       Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref CreateAuthCodeFunction
         - DynamoDBReadPolicy:
             TableName: !Ref QuestionsTable
+        - DynamoDBReadPolicy:
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+        - DynamoDBWritePolicy:
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
         - DynamoDBReadPolicy:
             TableName: !Ref PersonalIdentityTable
         - DynamoDBWritePolicy:
@@ -530,6 +550,13 @@ Resources:
         - Statement:
             Effect: Allow
             Action:
+              - ssm:GetParameters
+              - ssm:GetParameter
+            Resource:
+              - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
+        - Statement:
+            Effect: Allow
+            Action:
               - logs:*
             Resource:
               - "*"
@@ -538,6 +565,8 @@ Resources:
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
       DefinitionSubstitutions:
+        CommonStackName: !Ref CommonStackName
+        CreateAuthCodeFunctionArn: !GetAtt CreateAuthCodeFunction.Arn
         AnswersIvqStateMachine: !Ref "PostIvqAnswersStateMachine"
         QuestionsTableName: !Ref "QuestionsTable"
         ExecuteStateMachineFunctionName: !Ref "ExecuteStateMachineFunction"
@@ -663,6 +692,13 @@ Resources:
       RetentionInDays: 30
 
 Outputs:
+  CreateAuthCodeFunction:
+    Description: "Create Authorization Code Function ARN"
+    Value: !GetAtt CreateAuthCodeFunction.Arn
+  CreateAuthCodeFunctionRoleArn:
+    Description: "Create Authorization Code Function Arn"
+    Value: !GetAtt CreateAuthCodeFunctionRole.Arn
+
   ExecuteStateMachineFunction:
     Description: "ExecuteStateMachine Lambda Function ARN"
     Value: !GetAtt ExecuteStateMachineFunction.Arn

--- a/lambdas/submit-answer/src/create-auth-code-handler.ts
+++ b/lambdas/submit-answer/src/create-auth-code-handler.ts
@@ -1,0 +1,23 @@
+import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { Logger } from "@aws-lambda-powertools/logger";
+
+const logger = new Logger();
+const DEFAULT_AUTHORIZATION_CODE_TTL_IN_MILLIS = 600 * 1000;
+
+export class CreateAuthCodeHandler implements LambdaInterface {
+  public async handler(_event: unknown, _context: unknown): Promise<any> {
+    try {
+      return {
+        authCodeExpiry: Math.floor(
+          (Date.now() + DEFAULT_AUTHORIZATION_CODE_TTL_IN_MILLIS) / 1000
+        ),
+      };
+    } catch (error: any) {
+      logger.error("Error in CreateAuthCodeHandler: " + error.message);
+      throw error;
+    }
+  }
+}
+
+const handlerClass = new CreateAuthCodeHandler();
+export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/lambdas/submit-answer/tests/create-auth-code-handler.test.ts
+++ b/lambdas/submit-answer/tests/create-auth-code-handler.test.ts
@@ -1,0 +1,22 @@
+import { Context } from "aws-lambda";
+import { CreateAuthCodeHandler } from "../src/create-auth-code-handler";
+
+describe("create-auth-code-handler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  it("should return an expiry 10 minutes after Date.now()", async () => {
+    const mayThirtyOne2021 = 1622502000000;
+    jest.spyOn(Date, "now").mockReturnValue(mayThirtyOne2021);
+
+    const handler = new CreateAuthCodeHandler();
+    const result = await handler.handler({} as unknown, {} as Context);
+    const mayThirtyOne2021Plus10MinsInSeconds = 1622502600;
+
+    expect(result).toEqual({
+      authCodeExpiry: mayThirtyOne2021Plus10MinsInSeconds,
+    });
+  });
+});

--- a/step-functions/post-answer.asl.json
+++ b/step-functions/post-answer.asl.json
@@ -212,8 +212,62 @@
           "BackoffRate": 2
         }
       ],
-      "Next": "HTTP 200 - question has been answered successfully",
+      "Next": "Fetch Auth Code Expiry",
       "ResultPath": null
+    },
+    "Fetch Auth Code Expiry": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName": "${CreateAuthCodeFunctionArn}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 6,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Fetch Session Table Name",
+      "ResultPath": "$.expiry"
+    },
+    "Fetch Session Table Name": {
+      "Type": "Task",
+      "Next": "Set Auth Code for Session",
+      "Parameters": {
+        "Name": "/${CommonStackName}/SessionTableName"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
+      "ResultPath": "$.sessionTable"
+    },
+    "Set Auth Code for Session": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:updateItem",
+      "Parameters": {
+        "TableName.$": "$.sessionTable.Parameter.Value",
+        "Key": {
+          "sessionId": {
+            "S.$": "$$.Execution.Input.sessionId"
+          }
+        },
+        "UpdateExpression": "SET authorizationCode = :authCode, authorizationCodeExpiryDate = :expiry",
+        "ExpressionAttributeValues": {
+          ":authCode": {
+            "S.$": "States.UUID()"
+          },
+          ":expiry": {
+            "N.$": "States.Format('{}',$.expiry.Payload.authCodeExpiry)"
+          }
+        }
+      },
+      "Next": "HTTP 200 - question has been answered successfully"
     },
     "Error: The question has already been answered": {
       "Type": "Pass",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Added authorizationCode generation to the post answers state machine.
For now, this happens after we POST all the answers to HMRC
<!-- Describe the changes in detail - the "what"-->

### Why did it change
authorizationCodes are needed as part of the OAuth flow.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related XXXXJira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1904](https://govukverify.atlassian.net/browse/OJ-1904)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1904]: https://govukverify.atlassian.net/browse/OJ-1904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ