### PR TITLE
OJ-1957: Add error handling to get-ivq-questions State Machine

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -107,10 +107,14 @@ paths:
       summary: "Get question from HMRC"
       parameters:
         - $ref: "#/components/parameters/SessionHeader"
+      x-amazon-apigateway-request-validator: "Validate both"
       responses:
         "200":
-          description: "200 response"
-      x-amazon-apigateway-request-validator: "Validate both"
+          description: OK
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         passthroughBehavior: "when_no_templates"
@@ -123,15 +127,28 @@ paths:
           application/json:
             Fn::Sub: |-
               {
-                "input": "{\"sessionId\": \"$input.params('session-id')\"}",
+                "input": "{\"sessionId\": \"$input.params('session-id').trim()\"}",
                 "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-GetQuestion"
               }
         responses:
-          "200":
+          default:
             statusCode: 200
             responseTemplates:
-              application/json:
-                Fn::Sub: $input.path('$').output
+              application/json: |
+                #set($resp = $util.parseJson($input.body))
+                #set($params = $util.parseJson($resp.output))
+                #foreach($paramName in $params.keySet())
+                #if($paramName == 'error')
+                #set($err = true)
+                #end
+                #end
+                #if($err == true)
+                #set($context.responseOverride.status = 400)
+                #elseif($resp.status == "FAILED")
+                #set($context.responseOverride.status = 500)
+                $resp.cause
+                #end
+                $resp.output
   /answer:
     post:
       summary: "Post answer to HMRC"

--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -147,6 +147,8 @@ paths:
                 #elseif($resp.status == "FAILED")
                 #set($context.responseOverride.status = 500)
                 $resp.cause
+                #elseif($resp.output == "204")
+                #set($context.responseOverride.status = 204)
                 #end
                 $resp.output
   /answer:

--- a/lambdas/fetch-questions/src/fetch-questions-handler.ts
+++ b/lambdas/fetch-questions/src/fetch-questions-handler.ts
@@ -21,7 +21,7 @@ export class FetchQuestionsHandler implements LambdaInterface {
       try {
         json = await response.json();
       } catch (error: any) {
-        return await response.text();
+        throw new Error(await response.text());
       }
       if (json.questions.length <= 0) {
         throw new Error("No questions returned");

--- a/lambdas/fetch-questions/src/fetch-questions-handler.ts
+++ b/lambdas/fetch-questions/src/fetch-questions-handler.ts
@@ -1,19 +1,37 @@
 import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { Logger } from "@aws-lambda-powertools/logger";
+
+const logger = new Logger();
 
 export class FetchQuestionsHandler implements LambdaInterface {
+
   public async handler(event: any, _context: unknown): Promise<string> {
-    const response = await fetch(event.parameters.url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "User-Agent": event.parameters.userAgent,
-        Authorization: "Bearer " + event.bearerToken.value,
-      },
-      body: JSON.stringify({
-        nino: event.nino,
-      }),
-    });
-    return await response.json();
+    try {
+      const response = await fetch(event.parameters.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": event.parameters.userAgent,
+          Authorization: "Bearer " + event.bearerToken.value,
+        },
+        body: JSON.stringify({
+          nino: event.nino,
+        }),
+      });
+      let json;
+      try {
+        json = await response.json();
+      } catch (error: any) {
+        return await response.text();
+      }
+      if(json.questions.length <= 0) {
+        throw new Error("No questions returned");
+      }
+      return json;
+    } catch (error: any) {
+      logger.error("Error in MatchingHandler: " + error.message);
+      throw error;
+    }
   }
 }
 

--- a/lambdas/fetch-questions/src/fetch-questions-handler.ts
+++ b/lambdas/fetch-questions/src/fetch-questions-handler.ts
@@ -4,7 +4,6 @@ import { Logger } from "@aws-lambda-powertools/logger";
 const logger = new Logger();
 
 export class FetchQuestionsHandler implements LambdaInterface {
-
   public async handler(event: any, _context: unknown): Promise<string> {
     try {
       const response = await fetch(event.parameters.url, {
@@ -24,7 +23,7 @@ export class FetchQuestionsHandler implements LambdaInterface {
       } catch (error: any) {
         return await response.text();
       }
-      if(json.questions.length <= 0) {
+      if (json.questions.length <= 0) {
         throw new Error("No questions returned");
       }
       return json;

--- a/lambdas/fetch-questions/tests/fetch-questions-handler.test.ts
+++ b/lambdas/fetch-questions/tests/fetch-questions-handler.test.ts
@@ -1,10 +1,103 @@
 import { FetchQuestionsHandler } from "../src/fetch-questions-handler";
 import { Context } from "aws-lambda";
 
+const smInput = {
+  parameters: {
+    url: "dummyUrl",
+    userAgent: "dummyUserAgent",
+  },
+  bearerToken: {
+    value: "dummyOAuthToken",
+  },
+  nino: "dummyNino",
+};
+
 describe("fetch-questions-handler", () => {
-  it("should print Hello, World!", async () => {
-    const fetchQuestionsHandler = new FetchQuestionsHandler();
-    const result = await fetchQuestionsHandler.handler({}, {} as Context);
-    expect(result).toStrictEqual("Hello, World!");
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Success Scenarios", async () => {
+    it("should return a set of questions for a valid nino", async () => {
+      global.fetch = jest.fn().mockImplementation(() => {
+        return new Promise((resolve, reject) => {
+          resolve({
+            json: () => {
+              return {
+                correlationId: "dummyCorrelationId",
+                questions: [
+                  {
+                    questionKey: "dummyQuestionKey",
+                    info: {},
+                  },
+                  {
+                    questionKey: "dummyQuestionKey1",
+                    info: {
+                      dummyChoice: "dummyChoice",
+                    },
+                  },
+                ],
+              };
+            },
+          });
+        });
+      });
+    });
+
+    describe("Failure Scenarios", async () => {
+      const fetchQuestionsHandler = new FetchQuestionsHandler();
+      const result = await fetchQuestionsHandler.handler(
+        smInput,
+        {} as Context
+      );
+      expect(result).toEqual({
+        correlationId: "dummyCorrelationId",
+        questions: [
+          {
+            questionKey: "dummyQuestionKey",
+            info: {},
+          },
+          {
+            questionKey: "dummyQuestionKey1",
+            info: {
+              dummyChoice: "dummyChoice",
+            },
+          },
+        ],
+      });
+    });
+
+    it("should throw an error when HMRC returns no questions", async () => {
+      global.fetch = jest.fn().mockImplementation(() => {
+        return new Promise((resolve, reject) => {
+          resolve({
+            json: () => {
+              return {
+                correlationId: "dummyCorrelationId",
+                questions: [],
+              };
+            },
+          });
+        });
+      });
+      await expect(() =>
+        new FetchQuestionsHandler().handler(smInput, {} as Context)
+      ).rejects.toThrow("No questions returned");
+    });
+
+    it("should throw an error when HMRC does not return valid JSON", async () => {
+      global.fetch = jest.fn().mockImplementation(() => {
+        return new Promise((resolve, reject) => {
+          resolve({
+            text: () => {
+              return "dummyText";
+            },
+          });
+        });
+      });
+      await expect(() =>
+        new FetchQuestionsHandler().handler(smInput, {} as Context)
+      ).rejects.toThrow("dummyText");
+    });
   });
 });

--- a/step-functions/get-ivq-questions.asl.json
+++ b/step-functions/get-ivq-questions.asl.json
@@ -1,41 +1,7 @@
 {
   "Comment": "Populates the table of questions from the HMRC IVQ API",
-  "StartAt": "Check session ID present",
+  "StartAt": "Query questions table for session ID",
   "States": {
-    "Check session ID present": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Not": {
-            "Variable": "$.sessionId",
-            "IsPresent": true
-          },
-          "Next": "Error Session ID missing"
-        }
-      ],
-      "Default": "Check NINO present"
-    },
-    "Check NINO present": {
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Not": {
-            "Variable": "$.nino",
-            "IsPresent": true
-          },
-          "Next": "Error NINO missing"
-        }
-      ],
-      "Default": "Query questions table for session ID"
-    },
-    "Error NINO missing": {
-      "Type": "Pass",
-      "End": true
-    },
-    "Error Session ID missing": {
-      "Type": "Pass",
-      "End": true
-    },
     "Query questions table for session ID": {
       "Type": "Task",
       "Next": "Check if questions already exist for session",
@@ -60,7 +26,7 @@
           "Next": "Get Bearer Token"
         }
       ],
-      "Default": "Questions already loaded - Do Nothing"
+      "Default": "Questions already loaded - Do nothing"
     },
     "Get Bearer Token": {
       "Type": "Task",
@@ -110,8 +76,10 @@
       "Next": "Create Question Loop Counter",
       "Catch": [
         {
-          "ErrorEquals": ["States.ALL"],
-          "Next": "Error: FetchQuestions threw Exception"
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "Err: FetchQuestions threw Exception"
         }
       ]
     },
@@ -123,21 +91,21 @@
         "count.$": "States.ArrayLength($.Payload.questions)"
       },
       "ResultPath": "$.iterator",
-      "Next": "finished looping over all the questions?"
+      "Next": "Finished looping over all the questions?"
     },
-    "finished looping over all the questions?": {
+    "Finished looping over all the questions?": {
       "Comment": "Check if index is less than or equal to number of questions in the response for get ivq questions",
       "Type": "Choice",
       "Choices": [
         {
           "Variable": "$.iterator.index",
           "NumericLessThanPath": "$.iterator.count",
-          "Next": "get current question"
+          "Next": "Get current question"
         }
       ],
       "Default": "Filter questions"
     },
-    "get current question": {
+    "Get current question": {
       "Type": "Pass",
       "Parameters": {
         "count.$": "$.iterator.count",
@@ -145,10 +113,10 @@
         "correlationId.$": "$.Payload.correlationId",
         "index.$": "$.iterator.index"
       },
-      "Next": "Store question in DynamoDB",
+      "Next": "Store question",
       "ResultPath": "$.iterator"
     },
-    "Store question in DynamoDB": {
+    "Store question": {
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:putItem",
       "Parameters": {
@@ -172,9 +140,9 @@
         }
       },
       "ResultPath": "$.result",
-      "Next": "increment index by one"
+      "Next": "Increment index by one"
     },
-    "increment index by one": {
+    "Increment index by one": {
       "Type": "Pass",
       "Parameters": {
         "count.$": "$.iterator.count",
@@ -182,10 +150,10 @@
         "correlationId.$": "$.iterator.correlationId",
         "index.$": "States.MathAdd($.iterator.index, 1)"
       },
-      "Next": "continue looping?",
+      "Next": "Should we continue looping?",
       "ResultPath": "$.iterator"
     },
-    "continue looping?": {
+    "Should we continue looping?": {
       "Comment": "Exit loop when index exactly equal to number of questions",
       "Type": "Choice",
       "Choices": [
@@ -195,40 +163,41 @@
           "Next": "Filter questions"
         }
       ],
-      "Default": "finished looping over all the questions?"
+      "Default": "Finished looping over all the questions?"
     },
     "Filter questions": {
       "Type": "Pass",
-      "Next": "Are there sufficient questions?"
+      "Next": "Are there sufficient questions?",
+      "Comment": "TODO: Implement question filtering"
     },
-    "Error: FetchQuestions threw Exception": {
-      "Type": "Pass",
-      "End": true
+    "Err: FetchQuestions threw Exception": {
+      "Type": "Fail"
     },
     "Are there sufficient questions?": {
       "Type": "Choice",
       "Choices": [
         {
           "Not": {
-            "Variable": "$.sessionId",
+            "Variable": "$.Payload.questions",
             "IsPresent": true
           },
-          "Next": "Log: Insufficient questions"
+          "Next": "Err: Insufficient questions"
         }
       ],
-      "Default": "Log: Question Metric"
+      "Default": "Success"
     },
-    "Log: Insufficient questions": {
+    "Err: Insufficient questions": {
       "Type": "Pass",
-      "End": true
+      "End": true,
+      "Parameters": {
+        "error": "Insufficient Questions"
+      }
     },
-    "Log: Question Metric": {
-      "Type": "Pass",
-      "End": true
+    "Success": {
+      "Type": "Succeed"
     },
-    "Questions already loaded - Do Nothing": {
-      "Type": "Pass",
-      "End": true
+    "Questions already loaded - Do nothing": {
+      "Type": "Succeed"
     }
   }
 }

--- a/step-functions/get-ivq-questions.asl.json
+++ b/step-functions/get-ivq-questions.asl.json
@@ -76,9 +76,7 @@
       "Next": "Create Question Loop Counter",
       "Catch": [
         {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
+          "ErrorEquals": ["States.ALL"],
           "Next": "Err: FetchQuestions threw Exception"
         }
       ]

--- a/step-functions/get-ivq-questions.asl.json
+++ b/step-functions/get-ivq-questions.asl.json
@@ -148,10 +148,10 @@
         "correlationId.$": "$.iterator.correlationId",
         "index.$": "States.MathAdd($.iterator.index, 1)"
       },
-      "Next": "Should we continue looping?",
+      "Next": "Continue looping?",
       "ResultPath": "$.iterator"
     },
-    "Should we continue looping?": {
+    "Continue looping?": {
       "Comment": "Exit loop when index exactly equal to number of questions",
       "Type": "Choice",
       "Choices": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
This is a first pass at error handling for the get-ivq-questions.
The Lambda now catches exceptions, logs and re-throws. The Lambda will fail when there are no questions received from HMRC. 

The state machine has been changes to use pass states to represent 400s, fail states to represent 500s and success states for 200s. 

The OpenAPI file has been changes to return the correct status code depending on the returned error. 

<!-- Describe the changes in detail - the "what"-->

### Why did it change
We currently have no error handling in place so all requests gave a HTTP 200. 
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1975](https://govukverify.atlassian.net/browse/OJ-1975)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
