### PR TITLE
BAU: move object creation out of handler

### DIFF
--- a/lambdas/credential-subject/src/credential-subject-handler.ts
+++ b/lambdas/credential-subject/src/credential-subject-handler.ts
@@ -11,6 +11,7 @@ import {
 import { UserInfoEvent } from "./user-info-event";
 
 const logger = new Logger();
+const credentialSubjectBuilder = new CredentialSubjectBuilder();
 
 export class CredentialSubjectHandler implements LambdaInterface {
   public async handler(
@@ -18,7 +19,7 @@ export class CredentialSubjectHandler implements LambdaInterface {
     _context: unknown
   ): Promise<CredentialSubject> {
     try {
-      return new CredentialSubjectBuilder()
+      return credentialSubjectBuilder
         .addNames(this.convertEventInputToNames(event))
         .setAddresses(this.convertEventInputToAddress(event))
         .setBirthDate(


### PR DESCRIPTION
## Proposed changes

### What changed

Move builder creation out handler

### Why did it change

Best practice is to keep object initialization out of the handler
